### PR TITLE
[BIOMAGE-1651] Modified `rds login` to accept other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,15 @@ Sets up an ssh tunneling/port forwarding session for the rds server in a given e
 Example: set up an ssh tunnel to one of the staging rds endpoints
     biomage rds tunnel -i staging
 
-#### rds login
+#### rds run
 
-Logs into a database using psql and IAM if necessary.
+Run a command in the database cluster using IAM if necessary.
 Important: If you're not trying to connect in development, you'll need to run `biomage rds tunnel -i staging` first in a different terminal.
 
-Example: login to staging
-    biomage rds login -i staging
+Example: login into postgre console in staging
+    biomage rds run psql
+
+Example: dump the in staging
+    biomage rds run psql
+
+See `biomage rds run --help` for more details.

--- a/biomage/rds/login.py
+++ b/biomage/rds/login.py
@@ -16,14 +16,6 @@ from ..utils.constants import STAGING
     help="Input environment of the RDS server.",
 )
 @click.option(
-    "-p",
-    "--port",
-    required=False,
-    default=5432,
-    show_default=True,
-    help="Port of the db.",
-)
-@click.option(
     "-u",
     "--user",
     required=False,
@@ -39,18 +31,7 @@ from ..utils.constants import STAGING
     show_default=True,
     help="Region the RDS server is in.",
 )
-# Disabled, it doesn't change anything when there is only one instance
-# and might lead to confusion
-# @click.option(
-#     "-t",
-#     "--endpoint_type",
-#     required=False,
-#     default="reader",
-#     show_default=True,
-#     help="The type of the rds endpoint you want to connect to, can \
-#         be either reader or writer",
-# )
-def login(input_env, port, user, region, endpoint_type="writer"):
+def login(input_env, user, region):
     """
     Logs into a database using psql and IAM if necessary.\n
 
@@ -59,17 +40,12 @@ def login(input_env, port, user, region, endpoint_type="writer"):
     """
     password = None
 
-    internal_port = port
+    internal_port = 5432
 
     if input_env == "development":
         password = "password"
+        internal_port = 5431
     else:
-        internal_port = 5432
-        print(
-            "Only local port 5432 works connecting to staging and prod for now, \
-                so setting it to 5432"
-        )
-
         rds_client = boto3.client("rds")
 
         remote_endpoint = get_rds_endpoint(input_env, rds_client, endpoint_type)

--- a/biomage/rds/rds.py
+++ b/biomage/rds/rds.py
@@ -1,6 +1,6 @@
 import click
 
-from .login import login
+from .run import run
 from .tunnel import tunnel
 
 
@@ -13,4 +13,4 @@ def rds():
 
 
 rds.add_command(tunnel)
-rds.add_command(login)
+rds.add_command(run)

--- a/biomage/rds/tunnel.py
+++ b/biomage/rds/tunnel.py
@@ -23,27 +23,7 @@ from ..utils.constants import STAGING
     show_default=True,
     help="Region the RDS server is in.",
 )
-# Disabled, it doesn't change anything when there is only one instance
-# and might lead to confusion
-# @click.option(
-#     "-t",
-#     "--endpoint_type",
-#     required=False,
-#     default="reader",
-#     show_default=True,
-#     help="The type of the rds endpoint you want to connect to,
-#           can be either reader or writer",
-# )
-# Disabled, only 5432 works for now
-# @click.option(
-#     "-p",
-#     "--local_port",
-#     required=False,
-#     default=5432,
-#     show_default=True,
-#     help="Local port from which to connect.",
-# )
-def tunnel(input_env, region, endpoint_type="writer", local_port=5432):
+def tunnel(input_env, region, local_port=5432):
     """
     Sets up an ssh tunneling/port forwarding session
     for the rds server in a given environment.\n
@@ -52,6 +32,10 @@ def tunnel(input_env, region, endpoint_type="writer", local_port=5432):
     biomage rds tunnel -i staging
     """
 
+    # we use the writer endpoint because the reader endpoint might still connect to
+    # the writer endpoint when there's a single instance and provide a false
+    # sense of safety
+    endpoint_type = "writer"
     file_dir = pathlib.Path(__file__).parent.resolve()
     run(
         f"{file_dir}/tunnel.sh {input_env} {region} {local_port} {endpoint_type}",

--- a/biomage/rds/tunnel.sh
+++ b/biomage/rds/tunnel.sh
@@ -7,7 +7,7 @@ ENDPOINT_TYPE=$4
 function show_requirements() {
 	echo '
 ---------------------
-There was an error. 
+There was an error.
 ---------------------
 
 Please check if the following packages are installed: postgresql, jq.
@@ -59,7 +59,7 @@ AWS_PAGER="" aws ec2-instance-connect send-ssh-public-key --instance-id $INSTANC
 ssh -i temp -N -f -M -S temp-ssh.sock -L "$LOCAL_PORT:${RDSHOST}:5432" "ssm-user@${INSTANCE_ID}" -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -o ProxyCommand="aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p"
 
 echo "Finished setting up, run \"biomage rds login -i $ENVIRONMENT -r $REGION\" in a different tab"
-echo 
+echo
 echo "------------------------------"
 echo "Press enter to close session."
 echo "------------------------------"


### PR DESCRIPTION
Main: changed port to 5431.

Extra changes: `login` command to allow to dump the database and run other things than `psql`. Cleaned up also options that are currently not used.