### PR TITLE
Add nick to automatically generated staging name

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -206,7 +206,12 @@ def get_sandbox_id(templates, manifests, all_experiments, auto):
 
     # if we are in auto mode (non interactive) just generate a random sandbox ID name
     if auto:
-        return (user_name + "-" + random_name.generate_name()).lower()[:26]
+        return user_name + "-" + random_name.generate_name(
+            lists=(
+                random_name.dictionaries.ADJECTIVES,
+                random_name.dictionaries.ANIMALS,
+            )
+        ).lower()[:26].strip('-')
 
     fragments = (
         user_name,

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -206,12 +206,12 @@ def get_sandbox_id(templates, manifests, all_experiments, auto):
 
     # if we are in auto mode (non interactive) just generate a random sandbox ID name
     if auto:
-        return user_name + "-" + random_name.generate_name(
+        return (user_name + "-" + random_name.generate_name(
             lists=(
                 random_name.dictionaries.ADJECTIVES,
                 random_name.dictionaries.ANIMALS,
             )
-        ).lower()[:26].strip('-')
+        )).lower()[:26].strip('-')
 
     fragments = (
         user_name,

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -202,17 +202,14 @@ def get_sandbox_id(templates, manifests, all_experiments, auto):
             if opts.ref != DEFAULT_BRANCH
         ]
     )
+    user_name = re.sub(r"[^\w\s]", "", os.getenv("BIOMAGE_NICK", os.getenv("USER", "")))
 
     # if we are in auto mode (non interactive) just generate a random sandbox ID name
     if auto:
-        return (
-            os.getenv("BIOMAGE_NICK", os.getenv("USER", ""))
-            + "-"
-            + random_name.generate_name()
-        )
+        return (user_name + "-" + random_name.generate_name()).lower()[:26]
 
     fragments = (
-        re.sub(r"[^\w\s]", "", os.getenv("BIOMAGE_NICK", os.getenv("USER", ""))),
+        user_name,
         pr_ids if pr_ids else manifest_hash,
     )
     sandbox_id = "-".join([bit for bit in fragments if bit]).lower()[:26]

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -205,7 +205,11 @@ def get_sandbox_id(templates, manifests, all_experiments, auto):
 
     # if we are in auto mode (non interactive) just generate a random sandbox ID name
     if auto:
-        return random_name.generate_name()
+        return (
+            os.getenv("BIOMAGE_NICK", os.getenv("USER", ""))
+            + "-"
+            + random_name.generate_name()
+        )
 
     fragments = (
         re.sub(r"[^\w\s]", "", os.getenv("BIOMAGE_NICK", os.getenv("USER", ""))),


### PR DESCRIPTION
# Background
#### Link to issue 

the `--auto`option in the `biomage stage` command is very helpful in generating names automaticallly. However, the generated names does not contain the name of the user that generates the staging environment, making it difficult to see in Lens who created that staging environment with the automatically generated name.

This PR adds the username / `BIOMAGE_NICK` to the automatically generated name.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
