### PR TITLE
remove prompt to create new RDS

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -314,23 +314,6 @@ def create_manifest(templates, token, repo_to_ref, all_experiments, auto, with_r
     else:
         click.echo("Not pinning any repository")
 
-    # Only ask if we are not in auto mode and with_rds is not passed as flag
-    # In the case staging is not auto and --with_rds is passed as flag
-    # there is no need to ask this question
-    if not auto and not with_rds:
-        questions = [
-            {
-                "type": "confirm",
-                "name": "stage_rds",
-                "message": "Do you want to stage a separate RDS instance for this "
-                "staging environment?",
-                "default": False,
-            }
-        ]
-        click.echo()
-        answer = prompt(questions)
-        with_rds = answer["stage_rds"]
-
     # Find the latest SHA of the iac
     # Generate a list of manifests from all the url's we collected.
     manifests = []
@@ -384,7 +367,7 @@ def create_manifest(templates, token, repo_to_ref, all_experiments, auto, with_r
     manifests = manifests.replace("STAGING_RDS_SANDBOX_ID", rds_sandbox_id)
     manifests = base64.b64encode(manifests.encode()).decode()
 
-    return manifests, sandbox_id, with_rds
+    return manifests, sandbox_id
 
 
 def paginate_experiments(
@@ -608,7 +591,7 @@ def stage(token, org, deployments, with_rds, auto):
 
     all_experiments = get_all_experiments(config["production-experiments-table"])
 
-    manifest, sandbox_id, stage_rds = create_manifest(
+    manifest, sandbox_id = create_manifest(
         templates,
         token,
         repo_to_ref=repo_to_ref,
@@ -681,7 +664,7 @@ def stage(token, org, deployments, with_rds, auto):
             "sandbox-id": sandbox_id,
             # Convert stage_rds to string because Github has issues with boolean inputs
             # https://github.com/actions/runner/issues/1483
-            "with-rds": str(stage_rds),
+            "with-rds": str(with_rds),
             "secrets": secrets,
         },
     )


### PR DESCRIPTION
#### Background
A previous PR was added to add the capability to create a new RDS instance for a staging environment. The PR introduces a CLI flag and a new prompt when creating a new staging env. Creating a new RDS for staging is a rare thing to do, so this prompt, which added a new step, increases friction with little value. So this PR removes that.

### Testing
Staged environment:
*--auto --with_rds*
- https://ui-agi-freaky-opossum.scp-staging.biomage.net/

*--auto*
- https://ui-agi-dorky-uguisu.scp-staging.biomage.net/