### PR TITLE
Remove `biomage release` from test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ test: ## Tests that biomage cmd & subcommand are available
 	biomage rotate-ci --help > /dev/null
 	biomage stage --help > /dev/null
 	biomage unstage --help > /dev/null
-	biomage release --help > /dev/null
 	biomage account --help > /dev/null
 	@echo "    [✓]"
 	@echo


### PR DESCRIPTION
Tests are failing because the command `biomage release` does not exist. I checked the codebase and the command never existed. This might be a spillover from an experimental command. I'm removing the test for this so the test will pass.