### PR TITLE
specify env for biomage rds tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Currently download of the following files is supported:
 - Processed RDS file
 - Cell sets file
 
-**Note** this command needs `biomage rds tunnel` running in another tab to work.
+**Note** this command needs `biomage rds tunnel` running in another tab to work. By default the input environment is staging, so if you want to use production you will need to specify it in the -i option (`biomage rds tunnel -i production`).
 
 ### account
 A set of helper commands to aid with managing Cellenics account information (creating user accounts, changing passwords). See `biomage account --help` for more information, parameters and default values. Needs environmental variables `COGNITO_PRODUCTION_POOL` and/or `COGNITO_STAGING_POOL`.


### PR DESCRIPTION
# Background
Add a comment to specify that the default -i option for biomage rds tunnel is staging, and if you want to use production you have to specify it. 
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
