### PR TITLE
Revert rotate CI

### DIFF
--- a/biomage/rotate_ci/rotate_ci.py
+++ b/biomage/rotate_ci/rotate_ci.py
@@ -51,7 +51,7 @@ def format_name_for_cf(repo_name):
     return repo_name.replace("_", " ").replace("-", " ").title().replace(" ", "")
 
 
-def create_new_iam_users(iam, policies):
+def create_new_iam_users(policies):
     users = {}
 
     for repo, policies in policies.items():
@@ -264,7 +264,7 @@ def rotate_ci(token, org):
     policies = dict(policies)
 
     iam = boto3.client("iam", config=config)
-    create_new_iam_users(iam, policies)
+    create_new_iam_users(policies)
     keys = create_new_access_keys(iam, policies)
 
     result_codes = update_github_secrets(keys, token, org)


### PR DESCRIPTION
Revert rotate CI to the previous working state.

One fix was added only line 58, which is to replace underscores and dashes for repository names. Repository names will be used as resource names in the ci-users stack cloud formation. Underscores and dashes aren't allowed to be part of a cloudformation resource name, so having a repository with a dash or underscore in its name will throw an error.

Right now all our CI repos are single words (ui, api, pipeline, worker, testing). I've decided to leave this fix in to not cause a headache if we have future repositories having dashes or underscore in its name.