### PR TITLE
Remove random sandbox ids

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -221,6 +221,9 @@ def get_sandbox_id(templates, manifests, org, auto=False):
     )
     sandbox_id = "-".join([bit for bit in fragments if bit]).lower()[:26]
 
+    if auto:
+        return sandbox_id
+
     # Ask the user to provide one if they want
     click.echo()
     click.echo(click.style("Give a sandbox ID.", fg="yellow", bold=True))


### PR DESCRIPTION
The autogenerated sandbox ids are random if the stage command is run with the `--auto` flag instead of telling information about what PRs they are related to. 

This PR removes this randomness. As far as I can see, the random names don't really add value, they only make it harder to figure out whether a staging is still relevant when trying to clean up old stagings